### PR TITLE
Marks default case that should not return as unreachable

### DIFF
--- a/Source/wali/lib/graph/Functional.cpp
+++ b/Source/wali/lib/graph/Functional.cpp
@@ -1,6 +1,8 @@
 #include "wali/graph/Functional.hpp"
 #include "wali/graph/IntraGraph.hpp"
 
+#include "llvm/Support/ErrorHandling.h"
+
 #include <boost/cast.hpp>
 
 using namespace wali;
@@ -123,7 +125,7 @@ sem_elem_tensor_t SemElemFunctional::evaluate(IntraGraph * const gr)
        val = lhs->evaluate(gr);
        return boost::polymorphic_downcast<SemElemTensor*>(val->transpose().get_ptr());
     default:
-      assert(false && "[SemElemFunctiona::evaluate] Unknown case\n");
+      llvm_unreachable("[SemElemFunctiona::evaluate] Unknown case\n");
   }
 }
 


### PR DESCRIPTION
SemElemFunctional::evaluate has no sane way to return, if handling for the
FunctionType is not correct implemented, therefore, we should tell the
compiler that the default case should be unreachable.